### PR TITLE
General cleanup and fixes for tomcat7 and PyXDG errors, adding a /downloads location to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ apt-get install -y python-xdg
 # Copy X app start script to right location
 COPY startapp.sh /startapp.sh
 COPY firstrun.sh /etc/my_init.d/firstrun.sh
-COPY /src/jd2.tar /nobody/jd2.tar
+COPY /src/jd2.tar.gz /nobody/jd2.tar.gz
 RUN chmod +x /etc/my_init.d/firstrun.sh
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ mkdir -p /etc/my_init.d && \
 # Install packages needed for app
 export DEBCONF_NONINTERACTIVE_SEEN=true DEBIAN_FRONTEND=noninteractive && \
 apt-get update && \
-apt-get install -y firefox
+apt-get install -y firefox && \
+apt-get install -y python-xdg
 
 
 #########################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ apt-get install -y firefox
 COPY startapp.sh /startapp.sh
 COPY firstrun.sh /etc/my_init.d/firstrun.sh
 COPY /src/jd2.tar /nobody/jd2.tar
-RUN chmod +x /etc/my_init.d/firstrun.sh 
+RUN chmod +x /etc/my_init.d/firstrun.sh
 
 
 
@@ -58,4 +58,5 @@ RUN chmod +x /etc/my_init.d/firstrun.sh
 
 # Place whater volumes and ports you want exposed here:
 VOLUME ["/config"]
+VOLUME ["/downloads"]
 EXPOSE 3389 8080

--- a/firstrun.sh
+++ b/firstrun.sh
@@ -3,5 +3,9 @@
   if [ ! -d /config/jd2 ]; then
     tar -zxvf /nobody/jd2.tar.gz -C /config/
   fi
+  if [ ! -d /var/cache/tomcat7 ]; then
+    mkdir -p /var/cache/tomcat7
+    chown tomcat7:tomcat7 /var/cache/tomcat7
+  fi
   chown -R nobody:users /config
   chmod -R g+rw /config

--- a/firstrun.sh
+++ b/firstrun.sh
@@ -3,7 +3,7 @@
   mkdir -p /config/Downloads
   
   if [ ! -d /config/jd2 ]; then
-    tar -zxvf /nobody/jd2.tar -C /config/
+    tar -zxvf /nobody/jd2.tar.gz -C /config/
   fi
   chown -R nobody:users /config
   chmod -R g+rw /config

--- a/firstrun.sh
+++ b/firstrun.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-  mkdir -p /config/Downloads
-  
   if [ ! -d /config/jd2 ]; then
     tar -zxvf /nobody/jd2.tar.gz -C /config/
   fi


### PR DESCRIPTION
Janitorial:
- Some general cleanup tasks on logs that were left in place when the original tar file was compiled
- Renamed the gzipped tar file to "tar.gz" rather than "tar"

Bug Fix:
- PyXDG errors in the log after starting, resolves a "black screen" issue with JDownloader2 immediately following installation on some systems.
- Tomcat7 cache directory issues given a missing /cache/tomcat7 location. Greatly speeds up starting the container after the first time, may speed up usage while container is running (not sure what specifically it's used for beyond temp cache for war contents across tomcat restarts)

Feature Add:
- Added "/downloads" to Dockerfile, right now the user is forced to put downloads within the /config directory, however in many cases for unraid /downloads may well be preferred on the array itself while the /config may be better held on the cache drive (or similar).